### PR TITLE
Fix undefined private keys

### DIFF
--- a/src/components/Process/Detail.tsx
+++ b/src/components/Process/Detail.tsx
@@ -121,14 +121,18 @@ const Detail = () => {
       </Flex>
       {/*Organization card and other cards*/}
       <Grid templateColumns={{ base: 'repeat(2, 1fr)', lg: 'repeat(4, 1fr)' }} gap={4}>
-        <GridItem colSpan={2}>
-          <OrganizationCard minH={'115px'} />
+        <GridItem colSpan={2} display='flex'>
+          <OrganizationCard flex='1' />
         </GridItem>
-        <GridItem colSpan={1}>
-          <InfoCard title={t('processes.envelope_recount')}>{election.voteCount}</InfoCard>
+        <GridItem colSpan={1} display='flex'>
+          <InfoCard title={t('processes.envelope_recount')} flex='1'>
+            {election.voteCount}
+          </InfoCard>
         </GridItem>
-        <GridItem colSpan={1}>
-          <InfoCard title={t('processes.total_questions')}>{election.questions.length}</InfoCard>
+        <GridItem colSpan={1} display='flex'>
+          <InfoCard title={t('processes.total_questions')} flex='1'>
+            {election.questions.length}
+          </InfoCard>
         </GridItem>
       </Grid>
       {/*Encrypted votes */}

--- a/src/components/Process/Detail.tsx
+++ b/src/components/Process/Detail.tsx
@@ -199,10 +199,10 @@ const ElectionKeys = ({ electionId }: { electionId: string }) => {
       </Text>
       <Grid templateColumns={{ base: 'repeat(2, 1fr)', xl: 'repeat(4, 1fr)' }} gap={4}>
         <GridItem colSpan={1}>
-          <InfoCard title={t('processes.published_keys')}>{data.publicKeys.length}</InfoCard>
+          <InfoCard title={t('processes.published_keys')}>{data.publicKeys?.length ?? 0}</InfoCard>
         </GridItem>
         <GridItem colSpan={1}>
-          <InfoCard title={t('processes.revealed')}>{data.privateKeys.length}</InfoCard>
+          <InfoCard title={t('processes.revealed')}>{data.privateKeys?.length ?? 0}</InfoCard>
         </GridItem>
       </Grid>
     </Flex>

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -133,7 +133,7 @@
       "notAutostart": "Sense inici automàtic"
     },
     "published_keys": "Claus publicades",
-    "revealed": "Revelat",
+    "revealed": "Revelades",
     "total_questions": "Total de preguntes"
   },
   "raw": "Dades",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -133,7 +133,7 @@
       "notAutostart": "No inicio automático"
     },
     "published_keys": "Claves publicadas",
-    "revealed": "Revelados",
+    "revealed": "Reveladas",
     "total_questions": "Total de preguntas"
   },
   "raw": "Datos",


### PR DESCRIPTION
If keys on an encrypted alection are not revealed yet an error was shown:

![image](https://github.com/user-attachments/assets/a1b0758e-ea5c-472d-8625-7970b2ef29de)

This PR fixes this and also:

- Improve translations
- Fix layout to make all cards have the same height