### PR TITLE
Fix Math.ceil

### DIFF
--- a/src/components/Organizations/Details/Transfers.tsx
+++ b/src/components/Organizations/Details/Transfers.tsx
@@ -55,8 +55,9 @@ interface AccountTransfersProps {
 }
 
 const AccountTransfers = (txProps: AccountTransfersProps) => {
+  const txCount: number = txProps.txCount ?? 1
   return (
-    <PaginationProvider totalPages={Math.ceil(txProps.txCount ?? 0 / PaginationItemsPerPage)}>
+    <PaginationProvider totalPages={Math.ceil(txCount / PaginationItemsPerPage)}>
       <AccountTransfersTable {...txProps} />
     </PaginationProvider>
   )
@@ -68,7 +69,7 @@ const AccountTransfersTable = ({ txCount, org }: AccountTransfersProps) => {
 
   const { data, isLoading, isError, error } = useAccountTransfers({
     address: org.address,
-    page: Number(page) - 1 || 0,
+    page: page,
     options: {
       enabled: !!txCount && txCount > 0,
       retry: retryUnlessNotFound,


### PR DESCRIPTION
Strange react bug causes Math ceil to do not calculate well the number of pages if there are less than 10 items