### PR TITLE
Improve links

### DIFF
--- a/src/components/Blocks/BlockCard.tsx
+++ b/src/components/Blocks/BlockCard.tsx
@@ -3,12 +3,11 @@ import { BlockError, BlockNotFoundError } from '@vocdoni/extended-sdk'
 import { IChainBlockInfoResponse } from '@vocdoni/sdk'
 import { Trans, useTranslation } from 'react-i18next'
 import { BiTransferAlt } from 'react-icons/bi'
-
 import { generatePath } from 'react-router-dom'
 import { ReducedTextAndCopy } from '~components/Layout/CopyButton'
+import LinkCard from '~components/Layout/LinkCard'
 import { RoutePath } from '~constants'
 import { useDateFns } from '~i18n/use-date-fns'
-import LinkCard from '~components/Layout/LinkCard'
 
 export const BlockCard = ({ block }: { block: IChainBlockInfoResponse | BlockError }) => {
   if (block instanceof BlockError) return <BlockErrorCard error={block} height={block.height} />

--- a/src/components/Blocks/BlockCard.tsx
+++ b/src/components/Blocks/BlockCard.tsx
@@ -1,13 +1,14 @@
-import { Box, Card, CardBody, Flex, Link, HStack, Icon, Text } from '@chakra-ui/react'
+import { Box, Card, CardBody, Flex, HStack, Icon, Text } from '@chakra-ui/react'
 import { BlockError, BlockNotFoundError } from '@vocdoni/extended-sdk'
 import { IChainBlockInfoResponse } from '@vocdoni/sdk'
 import { Trans, useTranslation } from 'react-i18next'
 import { BiTransferAlt } from 'react-icons/bi'
 
-import { generatePath, Link as RouterLink } from 'react-router-dom'
+import { generatePath } from 'react-router-dom'
 import { ReducedTextAndCopy } from '~components/Layout/CopyButton'
 import { RoutePath } from '~constants'
 import { useDateFns } from '~i18n/use-date-fns'
+import LinkCard from '~components/Layout/LinkCard'
 
 export const BlockCard = ({ block }: { block: IChainBlockInfoResponse | BlockError }) => {
   if (block instanceof BlockError) return <BlockErrorCard error={block} height={block.height} />
@@ -36,34 +37,32 @@ const BlockInfoCard = ({
   const { formatDistance } = useDateFns()
 
   return (
-    <Card>
-      <Link as={RouterLink} to={generatePath(RoutePath.Block, { height: height.toString(), page: null })}>
-        <CardBody>
-          <Flex gap={1} direction={'column'}>
-            <Flex gap={3}>
-              <Text fontWeight='bold'># {height}</Text>
-              <HStack spacing={1}>
-                <Icon as={BiTransferAlt} boxSize={5} />
-                <Text fontSize={'sm'} fontWeight={'bold'}>
-                  {txn}
-                </Text>
-              </HStack>
-              <Text fontWeight={100} color={'lighterText'}>
-                {formatDistance(date, new Date())}
+    <LinkCard to={generatePath(RoutePath.Block, { height: height.toString(), page: null })}>
+      <CardBody>
+        <Flex gap={1} direction={'column'}>
+          <Flex gap={3}>
+            <Text fontWeight='bold'># {height}</Text>
+            <HStack spacing={1}>
+              <Icon as={BiTransferAlt} boxSize={5} />
+              <Text fontSize={'sm'} fontWeight={'bold'}>
+                {txn}
               </Text>
-            </Flex>
-            <Box fontSize={'sm'}>
-              <Flex gap={2} align={'center'}>
-                <Trans i18nKey='blocks.proposer'>Proposer:</Trans>
-                <ReducedTextAndCopy color={'textAccent1'} toCopy={proposer}>
-                  {proposer}
-                </ReducedTextAndCopy>
-              </Flex>
-            </Box>
+            </HStack>
+            <Text fontWeight={100} color={'lighterText'}>
+              {formatDistance(date, new Date())}
+            </Text>
           </Flex>
-        </CardBody>
-      </Link>
-    </Card>
+          <Box fontSize={'sm'}>
+            <Flex gap={2} align={'center'}>
+              <Trans i18nKey='blocks.proposer'>Proposer:</Trans>
+              <ReducedTextAndCopy color={'textAccent1'} toCopy={proposer}>
+                {proposer}
+              </ReducedTextAndCopy>
+            </Flex>
+          </Box>
+        </Flex>
+      </CardBody>
+    </LinkCard>
   )
 }
 

--- a/src/components/Layout/CopyButton.tsx
+++ b/src/components/Layout/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonProps, IconButton, Tooltip, useBreakpointValue, useClipboard } from '@chakra-ui/react'
+import { Button, ButtonProps, IconButton, Link, Tooltip, useBreakpointValue, useClipboard } from '@chakra-ui/react'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { IoCheckmark, IoCopy } from 'react-icons/io5'
@@ -72,18 +72,17 @@ export const ReducedTextAndCopy = ({
   if (to) {
     return (
       <>
-        <Button
+        <Link
           as={RouterLink}
           to={to}
           variant={'text'}
           aria-label={children}
           h={6} // Fixes the alignment caused to combine buttons with text
-          {...rest}
           mr={0}
           pr={0}
         >
           {text}
-        </Button>
+        </Link>
         <CopyButtonIcon h={6} {...rest} justifyContent={'start'} ml={2} pl={0} />
       </>
     )

--- a/src/components/Layout/LinkCard.tsx
+++ b/src/components/Layout/LinkCard.tsx
@@ -1,0 +1,14 @@
+import { Card, CardProps, LinkBox, LinkOverlay } from '@chakra-ui/react'
+import { Link as RouterLink } from 'react-router-dom'
+
+const LinkCard = ({ to, ...rest }: { to: string } & CardProps) => {
+  return (
+    <LinkBox w={'full'} h={'full'}>
+      <LinkOverlay as={RouterLink} to={to}>
+        <Card {...rest} variant={'link'} />
+      </LinkOverlay>
+    </LinkBox>
+  )
+}
+
+export default LinkCard

--- a/src/components/Organizations/Card.tsx
+++ b/src/components/Organizations/Card.tsx
@@ -99,10 +99,9 @@ export const SmallOrganizationCard = ({ id, flex, avatar }: { id: string; flex?:
       </Box>
       <Wrap spacingX={2} spacingY={0} align={'baseline'}>
         {orgName && (
-          <Text
+          <Link
             as={RouterLink}
             to={generatePath(RoutePath.Organization, { pid: id, page: null })}
-            color={'textAccent1'}
             size='xs'
             fontWeight={'normal'}
             variant={'text'}
@@ -110,7 +109,7 @@ export const SmallOrganizationCard = ({ id, flex, avatar }: { id: string; flex?:
             wordBreak='break-all'
           >
             {orgName}
-          </Text>
+          </Link>
         )}
         <ReducedTextAndCopy
           breakPoint={{ base: true }}

--- a/src/components/Organizations/Card.tsx
+++ b/src/components/Organizations/Card.tsx
@@ -1,10 +1,11 @@
-import { Box, BoxProps, Card, CardBody, CardProps, Flex, FlexProps, Link, Text, Wrap } from '@chakra-ui/react'
+import { Box, BoxProps, CardBody, CardProps, Flex, FlexProps, LinkBox, LinkOverlay, Text } from '@chakra-ui/react'
 import { OrganizationImage as Avatar, OrganizationName } from '@vocdoni/chakra-components'
 import { OrganizationProvider, useOrganization } from '@vocdoni/react-providers'
 import { Trans, useTranslation } from 'react-i18next'
 import { generatePath, Link as RouterLink } from 'react-router-dom'
 import { ReducedTextAndCopy } from '~components/Layout/CopyButton'
 import { FallbackAccountImg, RoutePath } from '~constants'
+import LinkCard from '~components/Layout/LinkCard'
 
 type IOrganizationCardProps = {
   id?: string
@@ -38,8 +39,7 @@ const OrganizationCardSkeleton = ({ electionCount: ec, ...rest }: IOrganizationC
   if (!pid) return null
 
   return (
-    <Card
-      as={RouterLink}
+    <LinkCard
       to={generatePath(RoutePath.Organization, { pid, page: null })}
       direction={'row'}
       alignItems='center'
@@ -55,28 +55,26 @@ const OrganizationCardSkeleton = ({ electionCount: ec, ...rest }: IOrganizationC
           }).toString()}
         />
       </Box>
-      <Link as={RouterLink} to={generatePath(RoutePath.Organization, { pid, page: null })}>
-        <CardBody>
-          {loading ? (
-            <Text fontWeight={'bold'} wordBreak='break-all' size='sm'>
-              {pid}
-            </Text>
-          ) : (
-            <OrganizationName fontWeight={'bold'} wordBreak='break-all' size='sm' />
-          )}
-          <ReducedTextAndCopy color={'textAccent1'} toCopy={pid}>
+      <CardBody>
+        {loading ? (
+          <Text fontWeight={'bold'} wordBreak='break-all' size='sm'>
             {pid}
-          </ReducedTextAndCopy>
-          {electionCount && (
-            <Text fontSize={'sm'}>
-              <Trans i18nKey={'organization.process_count'} count={electionCount}>
-                <strong>Process:</strong> {{ count: electionCount }}
-              </Trans>
-            </Text>
-          )}
-        </CardBody>
-      </Link>
-    </Card>
+          </Text>
+        ) : (
+          <OrganizationName fontWeight={'bold'} wordBreak='break-all' size='sm' />
+        )}
+        <ReducedTextAndCopy color={'textAccent1'} toCopy={pid}>
+          {pid}
+        </ReducedTextAndCopy>
+        {electionCount && (
+          <Text fontSize={'sm'}>
+            <Trans i18nKey={'organization.process_count'} count={electionCount}>
+              <strong>Process:</strong> {{ count: electionCount }}
+            </Trans>
+          </Text>
+        )}
+      </CardBody>
+    </LinkCard>
   )
 }
 
@@ -85,6 +83,7 @@ export const SmallOrganizationCard = ({ id, flex, avatar }: { id: string; flex?:
   const { t } = useTranslation()
 
   const orgName = organization?.account.name.default
+  const orgLink = generatePath(RoutePath.Organization, { pid: id, page: null })
 
   return (
     <Flex direction={'row'} alignItems={'center'} gap={2} {...flex}>
@@ -97,32 +96,22 @@ export const SmallOrganizationCard = ({ id, flex, avatar }: { id: string; flex?:
           }).toString()}
         />
       </Box>
-      <Wrap spacingX={2} spacingY={0} align={'baseline'}>
-        {orgName && (
-          <Link
-            as={RouterLink}
-            to={generatePath(RoutePath.Organization, { pid: id, page: null })}
-            size='xs'
-            fontWeight={'normal'}
-            variant={'text'}
-            pl={0}
-            wordBreak='break-all'
-          >
-            {orgName}
-          </Link>
-        )}
+      <LinkBox color={'link'} _hover={{ a: { color: 'accent1' } }}>
+        <LinkOverlay pr={orgName ? 4 : 0} as={RouterLink} to={orgLink}>
+          {orgName}
+        </LinkOverlay>
         <ReducedTextAndCopy
           breakPoint={{ base: true }}
           color={'textAccent1'}
           size='sm'
           toCopy={id}
-          to={generatePath(RoutePath.Organization, { pid: id, page: null })}
+          to={orgLink}
           pl={0}
           fontWeight={'normal'}
         >
           {id}
         </ReducedTextAndCopy>
-      </Wrap>
+      </LinkBox>
     </Flex>
   )
 }

--- a/src/components/Organizations/Details/OrgDetails.tsx
+++ b/src/components/Organizations/Details/OrgDetails.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Icon, Text } from '@chakra-ui/react'
+import { Flex, Icon, Link } from '@chakra-ui/react'
 import { OrganizationDescription } from '@vocdoni/chakra-components'
 import { AccountData, ensure0x } from '@vocdoni/sdk'
 import { Trans, useTranslation } from 'react-i18next'
@@ -25,23 +25,10 @@ const OrgDetails = ({ org }: { org: AccountData }) => {
     {
       label: t('organization.profile', { defaultValue: 'Profile' }),
       children: (
-        <Flex
-          as={'a'}
-          target='blank'
-          href={`${AppBaseURL}/organization/${ensure0x(org.address)}`}
-          align={'end'}
-          gap={3}
-          color={'blueText'}
-        >
-          <Box>
-            <Icon as={FaUserAlt} boxSize={3} />
-          </Box>
-          <Box>
-            <Text verticalAlign='bottom'>
-              <Trans i18nKey={'organization.view_profile'}></Trans>
-            </Text>
-          </Box>
-        </Flex>
+        <Link target='blank' href={`${AppBaseURL}/organization/${ensure0x(org.address)}`}>
+          <Icon as={FaUserAlt} boxSize={3} mr={2} />
+          <Trans i18nKey={'organization.view_profile'}></Trans>
+        </Link>
       ),
     },
     ...(org.account.description.default

--- a/src/components/Process/Card.tsx
+++ b/src/components/Process/Card.tsx
@@ -1,12 +1,13 @@
-import { Card, CardBody, CardProps, Flex, HStack, Link } from '@chakra-ui/react'
+import { CardBody, CardProps, Flex, HStack } from '@chakra-ui/react'
 import { ElectionSchedule, ElectionTitle } from '@vocdoni/chakra-components'
 import { ElectionProvider, OrganizationProvider, useElection } from '@vocdoni/react-providers'
 import { InvalidElection as InvalidElectionType, PublishedElection } from '@vocdoni/sdk'
-import { generatePath, Link as RouterLink } from 'react-router-dom'
+import { generatePath } from 'react-router-dom'
 import { ElectionStatusBadge } from '~components/Organizations/StatusBadge'
 import InvalidElection from '~components/Process/InvalidElection'
 import { RoutePath } from '~constants'
 import { SmallOrganizationCard } from '~components/Organizations/Card'
+import LinkCard from '~components/Layout/LinkCard'
 
 export type ElectionCardProps = { id?: string; election?: PublishedElection } & CardProps
 
@@ -36,27 +37,31 @@ const ElectionCardSkeleton = (rest: CardProps) => {
   }
 
   return (
-    <Card direction={'row'} alignItems='center' pl={4} {...rest}>
-      <Link as={RouterLink} to={generatePath(RoutePath.Process, { pid: election.id })} w='full'>
-        <CardBody>
-          <Flex direction={'column'} align={'start'} gap={4}>
-            <HStack>
-              <ElectionStatusBadge status={election.status} />
-              <ElectionSchedule
-                showRemaining
-                fontWeight={'normal'}
-                fontSize={'sm'}
-                textAlign={'start'}
-                fontStyle={'normal'}
-              />
-            </HStack>
-            <ElectionTitle textAlign={'start'} fontWeight={'bold'} wordBreak='break-all' fontSize='lg' />
-          </Flex>
-          <OrganizationProvider id={election.organizationId}>
-            <SmallOrganizationCard id={election.organizationId} />
-          </OrganizationProvider>
-        </CardBody>
-      </Link>
-    </Card>
+    <LinkCard
+      direction={'row'}
+      alignItems='center'
+      pl={4}
+      to={generatePath(RoutePath.Process, { pid: election.id })}
+      {...rest}
+    >
+      <CardBody>
+        <Flex direction={'column'} align={'start'} gap={4}>
+          <HStack>
+            <ElectionStatusBadge status={election.status} />
+            <ElectionSchedule
+              showRemaining
+              fontWeight={'normal'}
+              fontSize={'sm'}
+              textAlign={'start'}
+              fontStyle={'normal'}
+            />
+          </HStack>
+          <ElectionTitle textAlign={'start'} fontWeight={'bold'} wordBreak='break-all' fontSize='lg' />
+        </Flex>
+        <OrganizationProvider id={election.organizationId}>
+          <SmallOrganizationCard id={election.organizationId} />
+        </OrganizationProvider>
+      </CardBody>
+    </LinkCard>
   )
 }

--- a/src/components/Process/Detail.tsx
+++ b/src/components/Process/Detail.tsx
@@ -121,18 +121,14 @@ const Detail = () => {
       </Flex>
       {/*Organization card and other cards*/}
       <Grid templateColumns={{ base: 'repeat(2, 1fr)', lg: 'repeat(4, 1fr)' }} gap={4}>
-        <GridItem colSpan={2} display='flex'>
-          <OrganizationCard flex='1' />
+        <GridItem colSpan={2}>
+          <OrganizationCard h={'full'} />
         </GridItem>
-        <GridItem colSpan={1} display='flex'>
-          <InfoCard title={t('processes.envelope_recount')} flex='1'>
-            {election.voteCount}
-          </InfoCard>
+        <GridItem colSpan={1}>
+          <InfoCard title={t('processes.envelope_recount')}>{election.voteCount}</InfoCard>
         </GridItem>
-        <GridItem colSpan={1} display='flex'>
-          <InfoCard title={t('processes.total_questions')} flex='1'>
-            {election.questions.length}
-          </InfoCard>
+        <GridItem colSpan={1}>
+          <InfoCard title={t('processes.total_questions')}>{election.questions.length}</InfoCard>
         </GridItem>
       </Grid>
       {/*Encrypted votes */}

--- a/src/components/Process/Detail.tsx
+++ b/src/components/Process/Detail.tsx
@@ -8,6 +8,7 @@ import {
   Grid,
   GridItem,
   Icon,
+  Link,
   Tab,
   TabList,
   TabPanel,
@@ -76,7 +77,6 @@ const Detail = () => {
       <HeroHeaderLayout header={<ElectionHeader fallbackSrc={FallbackHeaderImg} />}>
         <VStack gap={2}>
           <ElectionStatusBadge status={election.status} />
-
           <ElectionTitle />
           <ReducedTextAndCopy color={'textAccent1'} toCopy={id} fontWeight={'normal'} h={0} fontSize={'md'}>
             {id}
@@ -279,15 +279,15 @@ const EnvelopeCard = ({ envelope, count }: { envelope: IElectionVote; count: num
       </CardHeader>
       <CardBody>
         <Flex direction={'column'}>
-          <Text
+          <Link
             as={RouterLink}
             to={generatePath(RoutePath.Block, { height: envelope.blockHeight.toString(), page: null })}
           >
             <Trans i18nKey={'envelope.block'} height={envelope.blockHeight}>
               Block {{ height: envelope.blockHeight }}
             </Trans>
-          </Text>
-          <Text
+          </Link>
+          <Link
             as={RouterLink}
             to={generatePath(RoutePath.Transaction, {
               block: envelope.blockHeight.toString(),
@@ -297,10 +297,10 @@ const EnvelopeCard = ({ envelope, count }: { envelope: IElectionVote; count: num
             <Trans i18nKey={'envelope.tx_number'} transactionIndex={envelope.transactionIndex}>
               Transaction: {{ transactionIndex: envelope.transactionIndex }}
             </Trans>
-          </Text>
-          <Text as={RouterLink} to={generatePath(RoutePath.Envelope, { verifier: envelope.voteID })}>
+          </Link>
+          <Link as={RouterLink} to={generatePath(RoutePath.Envelope, { verifier: envelope.voteID })}>
             <Trans i18nKey={'envelope.details'}>Details</Trans>
-          </Text>
+          </Link>
         </Flex>
       </CardBody>
     </Card>

--- a/src/components/Transactions/TransactionCard.tsx
+++ b/src/components/Transactions/TransactionCard.tsx
@@ -1,9 +1,10 @@
-import { Box, Card, CardBody, Flex, Link, Tag, Text } from '@chakra-ui/react'
+import { Box, CardBody, Flex, Tag, Text } from '@chakra-ui/react'
 import { IChainTxReference, TransactionType } from '@vocdoni/sdk'
 import { Trans } from 'react-i18next'
-import { generatePath, Link as RouterLink } from 'react-router-dom'
+import { generatePath } from 'react-router-dom'
 import { ReducedTextAndCopy } from '~components/Layout/CopyButton'
 import { RoutePath } from '~constants'
+import LinkCard from '~components/Layout/LinkCard'
 
 export const TransactionTypeBadge = ({ transactionType }: { transactionType: TransactionType }) => {
   return (
@@ -21,33 +22,30 @@ export const TransactionCard = ({
   blockHeight,
 }: IChainTxReference) => {
   return (
-    <Card>
-      <Link
-        as={RouterLink}
-        to={generatePath(RoutePath.Transaction, {
-          block: blockHeight.toString(),
-          index: transactionIndex.toString(),
-        })}
-      >
-        <CardBody>
-          <Flex gap={1} direction={'column'}>
-            <Flex gap={3} direction={'column'}>
-              <Box>
-                <TransactionTypeBadge transactionType={transactionType} />
-              </Box>
-              <Text fontWeight='bold'># {transactionNumber}</Text>
-            </Flex>
-            <Box fontSize={'sm'}>
-              <Flex gap={2} align={'center'}>
-                <Trans i18nKey='blocks.proposer'>Hash:</Trans>
-                <ReducedTextAndCopy color={'textAccent1'} toCopy={transactionHash}>
-                  {transactionHash}
-                </ReducedTextAndCopy>
-              </Flex>
+    <LinkCard
+      to={generatePath(RoutePath.Transaction, {
+        block: blockHeight.toString(),
+        index: transactionIndex.toString(),
+      })}
+    >
+      <CardBody>
+        <Flex gap={1} direction={'column'}>
+          <Flex gap={3} direction={'column'}>
+            <Box>
+              <TransactionTypeBadge transactionType={transactionType} />
             </Box>
+            <Text fontWeight='bold'># {transactionNumber}</Text>
           </Flex>
-        </CardBody>
-      </Link>
-    </Card>
+          <Box fontSize={'sm'}>
+            <Flex gap={2} align={'center'}>
+              <Trans i18nKey='blocks.proposer'>Hash:</Trans>
+              <ReducedTextAndCopy color={'textAccent1'} toCopy={transactionHash}>
+                {transactionHash}
+              </ReducedTextAndCopy>
+            </Flex>
+          </Box>
+        </Flex>
+      </CardBody>
+    </LinkCard>
   )
 }

--- a/src/components/Transactions/TxDetails/TxDetails.tsx
+++ b/src/components/Transactions/TxDetails/TxDetails.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@chakra-ui/react'
+import { Link } from '@chakra-ui/react'
 import { ensure0x, TransactionType, Tx } from '@vocdoni/sdk'
 import { useTranslation } from 'react-i18next'
 import { generatePath, Link as RouterLink } from 'react-router-dom'
@@ -56,13 +56,9 @@ export const TxDetailsGrid = (tx: Tx) => {
     {
       label: t('transactions.block', { defaultValue: 'Block' }),
       children: (
-        <Text
-          as={RouterLink}
-          to={generatePath(RoutePath.Block, { height: blockHeight.toString(), page: null })}
-          color={'textAccent1'}
-        >
+        <Link as={RouterLink} to={generatePath(RoutePath.Block, { height: blockHeight.toString(), page: null })}>
           {blockHeight}
-        </Text>
+        </Link>
       ),
     },
     {

--- a/src/components/Validators/ValidatorCard.tsx
+++ b/src/components/Validators/ValidatorCard.tsx
@@ -1,9 +1,10 @@
-import { Card, CardBody, Flex, HStack, Link, Text } from '@chakra-ui/react'
+import { CardBody, Flex, HStack, Text } from '@chakra-ui/react'
 import { Trans } from 'react-i18next'
 import { ReducedTextAndCopy } from '~components/Layout/CopyButton'
-import { generatePath, Link as RouterLink } from 'react-router-dom'
+import { generatePath } from 'react-router-dom'
 import { RoutePath } from '~constants'
 import { ValidatorFixedType } from '~components/Validators/Detail'
+import LinkCard from '~components/Layout/LinkCard'
 
 export const ValidatorName = ({ name, useCopy, address }: { name?: string; useCopy?: boolean; address: string }) => {
   const showName = !!name
@@ -41,36 +42,34 @@ export const ValidatorName = ({ name, useCopy, address }: { name?: string; useCo
 
 export const ValidatorCard = (validator: ValidatorFixedType) => {
   return (
-    <Card>
-      <Link as={RouterLink} to={generatePath(RoutePath.Validator, { address: validator.validatorAddress })}>
-        <CardBody>
-          <Flex gap={2} direction={'column'}>
-            <ValidatorName name={validator.name} address={validator.validatorAddress} />
-            <Flex fontSize={'sm'} direction={'column'} gap={2}>
-              <HStack gap={1}>
-                <Text fontWeight={'bold'}>
-                  <Trans i18nKey='validators.pubkey'>PubKey:</Trans>
-                </Text>
-                <ReducedTextAndCopy
-                  color={'textAccent1'}
-                  toCopy={validator.pubKey}
-                  fontWeight={'normal'}
-                  h={0}
-                  fontSize={'sm'}
-                  p={0}
-                >
-                  {validator.pubKey}
-                </ReducedTextAndCopy>
-              </HStack>
+    <LinkCard to={generatePath(RoutePath.Validator, { address: validator.validatorAddress })}>
+      <CardBody>
+        <Flex gap={2} direction={'column'}>
+          <ValidatorName name={validator.name} address={validator.validatorAddress} />
+          <Flex fontSize={'sm'} direction={'column'} gap={2}>
+            <HStack gap={1}>
               <Text fontWeight={'bold'}>
-                <Trans i18nKey='validators.voting_power' values={{ power: validator.power }}>
-                  Voting power: {{ power: validator.power }}
-                </Trans>
+                <Trans i18nKey='validators.pubkey'>PubKey:</Trans>
               </Text>
-            </Flex>
+              <ReducedTextAndCopy
+                color={'textAccent1'}
+                toCopy={validator.pubKey}
+                fontWeight={'normal'}
+                h={0}
+                fontSize={'sm'}
+                p={0}
+              >
+                {validator.pubKey}
+              </ReducedTextAndCopy>
+            </HStack>
+            <Text fontWeight={'bold'}>
+              <Trans i18nKey='validators.voting_power' values={{ power: validator.power }}>
+                Voting power: {{ power: validator.power }}
+              </Trans>
+            </Text>
           </Flex>
-        </CardBody>
-      </Link>
-    </Card>
+        </Flex>
+      </CardBody>
+    </LinkCard>
   )
 }

--- a/src/theme/components/Card.ts
+++ b/src/theme/components/Card.ts
@@ -26,19 +26,21 @@ const link = definePartsStyle((props) => {
     ...theme.components.Card.variants?.elevated,
     container: {
       _hover: {
-        boxShadow: 'var(--box-shadow-darker)',
-        transition: 'box-shadow .2s  ',
         ..._hover,
+        boxShadow: 'var(--box-shadow-darker)',
+        transition: 'box-shadow .2s',
       },
       ...baseStyle.container,
       ...theme.components.Card.variants?.elevated.container,
     },
     header: {
       ...baseStyle.header,
+      transition: 'color .2s',
       _hover,
     },
     body: {
       ...baseStyle.body,
+      transition: 'color .2s',
       _hover,
     },
     footer: {

--- a/src/theme/components/Card.ts
+++ b/src/theme/components/Card.ts
@@ -1,5 +1,5 @@
 import { cardAnatomy } from '@chakra-ui/anatomy'
-import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
+import { createMultiStyleConfigHelpers, theme } from '@chakra-ui/react'
 
 const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpers(cardAnatomy.keys)
 
@@ -17,6 +17,40 @@ const baseStyle = definePartsStyle({
   },
 })
 
-const Card = defineMultiStyleConfig({ baseStyle })
+const link = definePartsStyle((props) => {
+  const _hover = {
+    color: 'accent1',
+  }
+  return {
+    ...baseStyle,
+    ...theme.components.Card.variants?.elevated,
+    container: {
+      _hover: {
+        boxShadow: 'var(--box-shadow-darker)',
+        transition: 'box-shadow .2s  ',
+        ..._hover,
+      },
+      ...baseStyle.container,
+      ...theme.components.Card.variants?.elevated.container,
+    },
+    header: {
+      ...baseStyle.header,
+      _hover,
+    },
+    body: {
+      ...baseStyle.body,
+      _hover,
+    },
+    footer: {
+      _hover,
+    },
+  }
+})
+
+const variants = {
+  link,
+}
+
+const Card = defineMultiStyleConfig({ baseStyle, variants })
 
 export default Card

--- a/src/theme/components/Link.ts
+++ b/src/theme/components/Link.ts
@@ -2,8 +2,8 @@ import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
 
 const baseStyle = defineStyle({
   color: 'link',
-  // textDecoration: 'underline',
   textDecoration: 'none',
+  transition: 'all .2s',
   _hover: {
     textDecoration: 'none',
     color: 'accent1',

--- a/src/theme/components/Link.ts
+++ b/src/theme/components/Link.ts
@@ -1,9 +1,12 @@
 import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
 
 const baseStyle = defineStyle({
+  color: 'link',
+  // textDecoration: 'underline',
+  textDecoration: 'none',
   _hover: {
     textDecoration: 'none',
-    color: 'link',
+    color: 'accent1',
   },
 })
 

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -6,6 +6,11 @@ import components from './components'
 const theme = extendTheme(vtheme, {
   components,
   colors,
+  styles: {
+    global: {
+      ':root': { '--box-shadow-darker': '0px 2px 4px #808080b5' },
+    },
+  },
 })
 
 export default theme


### PR DESCRIPTION
Fixes #69 

It improves how links are shown on the explorer (defining the color and the hover color).

Also it creates a Card variant called `link` used to manage the styles for the cards that are links. 

In addition, it uses the `LinkBox` and `LinkOverlay` [chakra components](https://v2.chakra-ui.com/docs/components/link-overlay/usage) to define the card links