### PR TITLE
Fix block txCount

### DIFF
--- a/src/components/Blocks/BlockCard.tsx
+++ b/src/components/Blocks/BlockCard.tsx
@@ -23,7 +23,9 @@ export const BlockCard = ({ block, compact = false }: IBlockCardProps) => {
   const height = block.header.height
   const time = block.header.time
   const proposer = block.header.proposerAddress
-  const txn = block.data.txs.length
+  // Not on the SDK yet
+  // @ts-ignore
+  const txn = block.txCount
 
   const date = new Date(time)
 

--- a/src/components/Blocks/Detail.tsx
+++ b/src/components/Blocks/Detail.tsx
@@ -66,7 +66,9 @@ const DetailsTab = ({ block }: { block: IChainBlockInfoResponse }) => {
     },
     {
       label: t('blocks.transactions', { defaultValue: 'Transactions' }),
-      children: block.data.txs.length,
+      // Not on the SDK yet
+      // @ts-ignore
+      children: block.txCount,
     },
     {
       label: t('blocks.hash', { defaultValue: 'Hash' }),
@@ -113,6 +115,9 @@ const DetailsTab = ({ block }: { block: IChainBlockInfoResponse }) => {
 export const BlockDetail = ({ block }: { block: IChainBlockInfoResponse }) => {
   const height = block.header.height
   const date = new Date(block.header.time)
+  // Not on the SDK yet
+  // @ts-ignore
+  const txCount = block.txCount
 
   const { formatDistance } = useDateFns()
 
@@ -145,7 +150,7 @@ export const BlockDetail = ({ block }: { block: IChainBlockInfoResponse }) => {
             <DetailsTab block={block} />
           </TabPanel>
           <TabPanel>
-            <PaginatedBlockTransactionsList blockHeight={height} totalTxs={block.data.txs.length} />
+            <PaginatedBlockTransactionsList blockHeight={height} totalTxs={txCount} />
           </TabPanel>
           <TabPanel>
             <RawContentBox obj={block} />


### PR DESCRIPTION
Fixes https://github.com/vocdoni/explorer/issues/63

Now block information will return `txCount` instead of a list of `txs`. 

Needs deployment on stg