### PR TITLE
Fix filter pagination

### DIFF
--- a/src/components/Accounts/List.tsx
+++ b/src/components/Accounts/List.tsx
@@ -20,7 +20,7 @@ export const AccountsFilter = () => {
       maxW={'300px'}
       placeholder={t('accounts.search_by_org_id')}
       onChange={(value: string) => {
-        navigate(generatePath(RoutePath.AccountsList, { page: '0', query: value as string }))
+        navigate(generatePath(RoutePath.AccountsList, { page: '1', query: value as string }))
       }}
       debounceTime={500}
       initialValue={query}

--- a/src/components/Accounts/List.tsx
+++ b/src/components/Accounts/List.tsx
@@ -4,60 +4,58 @@ import { generatePath, useNavigate, useParams } from 'react-router-dom'
 import { InputSearch } from '~components/Layout/Inputs'
 import { LoadingCards } from '~components/Layout/Loading'
 import { AccountCard } from '~components/Accounts/Card'
-import { RoutedPaginationProvider, useRoutedPagination } from '~components/Pagination/PaginationProvider'
+import { useRoutedPagination } from '~components/Pagination/PaginationProvider'
 import { RoutedPagination } from '~components/Pagination/RoutedPagination'
 import { RoutePath } from '~constants'
 import { useOrganizationCount, useOrganizationList } from '~queries/accounts'
 import { ContentError, NoResultsError } from '~components/Layout/ContentError'
+import useQueryParams from '~src/router/use-query-params'
+
+type FilterQueryParams = {
+  accountId?: string
+}
 
 export const AccountsFilter = () => {
   const { t } = useTranslation()
-  const navigate = useNavigate()
-  const { query } = useParams<{ query?: string }>()
+  const { queryParams, getNewParams } = useQueryParams<FilterQueryParams>()
+  const { setPage } = useRoutedPagination()
+  const setFilters = (filters: Partial<FilterQueryParams>) => {
+    setPage(1, `?${getNewParams(filters).toString()}`)
+  }
 
   return (
     <InputSearch
       maxW={'300px'}
       placeholder={t('accounts.search_by_org_id')}
       onChange={(value: string) => {
-        navigate(generatePath(RoutePath.AccountsList, { page: '1', query: value as string }))
+        setFilters({ accountId: value })
       }}
       debounceTime={500}
-      initialValue={query}
+      initialValue={queryParams.accountId}
     />
-  )
-}
-
-export const PaginatedAccountsList = () => {
-  return (
-    <RoutedPaginationProvider path={RoutePath.AccountsList}>
-      <AccountsList />
-    </RoutedPaginationProvider>
   )
 }
 
 export const AccountsList = () => {
   const { page }: { page?: number } = useRoutedPagination()
-  const { query }: { query?: string } = useParams()
-  const { data: count, isLoading: isLoadingCount } = useOrganizationCount()
+  const { queryParams } = useQueryParams<FilterQueryParams>()
+  const accountId = queryParams.accountId
 
   const {
     data: orgs,
-    isLoading: isLoadingOrgs,
+    isLoading,
     isFetching,
     isError,
     error,
   } = useOrganizationList({
     params: {
       page,
-      organizationId: query,
+      organizationId: accountId,
     },
     placeholderData: keepPreviousData,
   })
 
-  const isLoading = isLoadingCount || isLoadingOrgs
-
-  if (isLoading || (query && isFetching)) {
+  if (isLoading || (accountId && isFetching)) {
     return <LoadingCards skeletonCircle />
   }
 

--- a/src/components/Accounts/List.tsx
+++ b/src/components/Accounts/List.tsx
@@ -1,15 +1,13 @@
 import { keepPreviousData } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
-import { generatePath, useNavigate, useParams } from 'react-router-dom'
 import { InputSearch } from '~components/Layout/Inputs'
 import { LoadingCards } from '~components/Layout/Loading'
 import { AccountCard } from '~components/Accounts/Card'
 import { useRoutedPagination } from '~components/Pagination/PaginationProvider'
 import { RoutedPagination } from '~components/Pagination/RoutedPagination'
-import { RoutePath } from '~constants'
-import { useOrganizationCount, useOrganizationList } from '~queries/accounts'
+import { useOrganizationList } from '~queries/accounts'
 import { ContentError, NoResultsError } from '~components/Layout/ContentError'
-import useQueryParams from '~src/router/use-query-params'
+import { useRoutedPaginationQueryParams } from '~src/router/use-query-params'
 
 type FilterQueryParams = {
   accountId?: string
@@ -17,18 +15,14 @@ type FilterQueryParams = {
 
 export const AccountsFilter = () => {
   const { t } = useTranslation()
-  const { queryParams, getNewParams } = useQueryParams<FilterQueryParams>()
-  const { setPage } = useRoutedPagination()
-  const setFilters = (filters: Partial<FilterQueryParams>) => {
-    setPage(1, `?${getNewParams(filters).toString()}`)
-  }
+  const { queryParams, setQueryParams } = useRoutedPaginationQueryParams<FilterQueryParams>()
 
   return (
     <InputSearch
       maxW={'300px'}
       placeholder={t('accounts.search_by_org_id')}
       onChange={(value: string) => {
-        setFilters({ accountId: value })
+        setQueryParams({ accountId: value })
       }}
       debounceTime={500}
       initialValue={queryParams.accountId}
@@ -38,7 +32,7 @@ export const AccountsFilter = () => {
 
 export const AccountsList = () => {
   const { page }: { page?: number } = useRoutedPagination()
-  const { queryParams } = useQueryParams<FilterQueryParams>()
+  const { queryParams } = useRoutedPaginationQueryParams<FilterQueryParams>()
   const accountId = queryParams.accountId
 
   const {

--- a/src/components/Layout/ListPageLayout.tsx
+++ b/src/components/Layout/ListPageLayout.tsx
@@ -13,7 +13,12 @@ const ListPageLayout = ({
 } & PropsWithChildren) => {
   return (
     <Flex direction='column' mt={10} gap={6}>
-      <Flex direction={{ base: 'column', md: 'row' }} justify='space-between' gap={4} align={'center'}>
+      <Flex
+        direction={{ base: 'column', md: 'row' }}
+        justify='space-between'
+        gap={4}
+        align={{ base: 'center', lg: 'start' }}
+      >
         <Flex direction='column' textAlign={{ base: 'center', md: 'start' }}>
           <Heading isTruncated wordBreak='break-word'>
             {title}
@@ -21,7 +26,7 @@ const ListPageLayout = ({
           {subtitle && <Text color='lighterText'>{subtitle}</Text>}
         </Flex>
         {rightComponent && (
-          <Flex align='center' justify={{ base: 'center', md: 'end' }}>
+          <Flex mt={{ base: 0, md: 4 }} align='center' justify={{ base: 'center', md: 'end' }}>
             {rightComponent}
           </Flex>
         )}

--- a/src/components/Layout/TopBar.tsx
+++ b/src/components/Layout/TopBar.tsx
@@ -49,7 +49,7 @@ export const TopBar = () => {
   const links: HeaderLink[] = [
     {
       name: t('links.accounts', { defaultValue: 'Accounts' }),
-      url: generatePath(RoutePath.AccountsList, { page: null, query: null }),
+      url: generatePath(RoutePath.AccountsList, { page: null }),
     },
     {
       name: t('links.processes', { defaultValue: 'Processes' }),

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonGroup, ButtonGroupProps, ButtonProps, Input, InputProps, Text } from '@chakra-ui/react'
 import { ReactElement, useMemo, useState } from 'react'
-import { generatePath, Link as RouterLink, useLocation, useNavigate, useParams } from 'react-router-dom'
+import { Link as RouterLink } from 'react-router-dom'
 import { usePagination, useRoutedPagination } from './PaginationProvider'
 import { PaginationResponse } from '@vocdoni/sdk'
 import { Trans } from 'react-i18next'
@@ -203,22 +203,16 @@ export const Pagination = ({ maxButtons = 10, buttonProps, inputProps, paginatio
 }
 
 export const RoutedPagination = ({ maxButtons = 10, buttonProps, pagination, ...rest }: PaginationProps) => {
-  const { path } = useRoutedPagination()
-  const { search } = useLocation()
-  const { page, ...extraParams }: { page?: number } = useParams()
-  const navigate = useNavigate()
+  const { getPathForPage, setPage } = useRoutedPagination()
 
   const totalPages = pagination.lastPage + 1
-
   const currentPage = pagination.currentPage
-
-  const _generatePath = (page: number) => generatePath(path, { page, ...extraParams }) + search
 
   return (
     <PaginationButtons
-      goToPage={(page) => navigate(_generatePath(page))}
+      goToPage={(page) => setPage(page)}
       createPageButton={(i) => (
-        <RoutedPageButton key={i} to={_generatePath(i + 1)} page={i} currentPage={currentPage} {...buttonProps} />
+        <RoutedPageButton key={i} to={getPathForPage(i + 1)} page={i} currentPage={currentPage} {...buttonProps} />
       )}
       currentPage={currentPage}
       totalPages={totalPages}

--- a/src/components/Pagination/PaginationProvider.tsx
+++ b/src/components/Pagination/PaginationProvider.tsx
@@ -1,5 +1,5 @@
-import { createContext, PropsWithChildren, useContext, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { createContext, PropsWithChildren, useCallback, useContext, useState } from 'react'
+import { generatePath, useLocation, useNavigate, useParams } from 'react-router-dom'
 
 export type PaginationContextProps = {
   page: number
@@ -8,6 +8,10 @@ export type PaginationContextProps = {
 
 export type RoutedPaginationContextProps = Omit<PaginationContextProps, 'setPage'> & {
   path: string
+  // Util function that generates the path for a given page
+  // (it return the actual path with queryParams and other route params but changing the page)
+  getPathForPage: (page: number, queryParams?: string) => string
+  setPage: (page: number, queryParams?: string) => void
 }
 
 const PaginationContext = createContext<PaginationContextProps | undefined>(undefined)
@@ -36,10 +40,22 @@ export type RoutedPaginationProviderProps = PaginationProviderProps & {
 }
 
 export const RoutedPaginationProvider = ({ path, ...rest }: PropsWithChildren<RoutedPaginationProviderProps>) => {
-  const { page }: { page?: number } = useParams()
+  const { search } = useLocation()
+  const { page, ...extraParams }: { page?: number } = useParams()
   const p = page && page > 0 ? page - 1 : 0
 
-  return <RoutedPaginationContext.Provider value={{ page: p, path }} {...rest} />
+  const navigate = useNavigate()
+
+  const getPathForPage = (page: number, queryParams?: string) => {
+    const p = queryParams || search
+    return generatePath(path, { page, ...extraParams }) + p
+  }
+
+  const setPage = (page: number, queryParams?: string) => {
+    navigate(getPathForPage(page, queryParams))
+  }
+
+  return <RoutedPaginationContext.Provider value={{ page: p, path, getPathForPage, setPage }} {...rest} />
 }
 
 export const PaginationProvider = ({ ...rest }: PropsWithChildren<PaginationProviderProps>) => {

--- a/src/components/Process/ProcessList.tsx
+++ b/src/components/Process/ProcessList.tsx
@@ -17,9 +17,8 @@ import { Trans, useTranslation } from 'react-i18next'
 import { InputSearch } from '~components/Layout/Inputs'
 import { LoadingCards } from '~components/Layout/Loading'
 import { ContentError, NoResultsError } from '~components/Layout/ContentError'
-import { RoutedPaginationProvider, useRoutedPagination } from '~components/Pagination/PaginationProvider'
+import { useRoutedPagination } from '~components/Pagination/PaginationProvider'
 import { RoutedPagination } from '~components/Pagination/RoutedPagination'
-import { RoutePath } from '~constants'
 import { useProcessList } from '~queries/processes'
 import useQueryParams from '~src/router/use-query-params'
 import { isEmpty } from '~utils/objects'
@@ -33,7 +32,12 @@ type FilterQueryParams = {
 }
 
 const PopoverFilter = () => {
-  const { queryParams, setQueryParams } = useQueryParams<FilterQueryParams>()
+  const { queryParams, getNewParams } = useQueryParams<FilterQueryParams>()
+  const { setPage } = useRoutedPagination()
+
+  const setFilters = (filters: Partial<FilterQueryParams>) => {
+    setPage(1, `?${getNewParams(filters).toString()}`)
+  }
 
   return (
     <Popover>
@@ -45,19 +49,19 @@ const PopoverFilter = () => {
           <Flex direction={'column'}>
             <Checkbox
               isChecked={queryParams.withResults === 'true'}
-              onChange={(e) => setQueryParams({ ...queryParams, withResults: e.target.checked ? 'true' : undefined })}
+              onChange={(e) => setFilters({ ...queryParams, withResults: e.target.checked ? 'true' : undefined })}
             >
               <Trans i18nKey='process.show_with_results'>Show only processes with results</Trans>
             </Checkbox>
             <Checkbox
               isChecked={queryParams.finalResults === 'true'}
-              onChange={(e) => setQueryParams({ ...queryParams, finalResults: e.target.checked ? 'true' : undefined })}
+              onChange={(e) => setFilters({ ...queryParams, finalResults: e.target.checked ? 'true' : undefined })}
             >
               <Trans i18nKey='process.final_results'>Final results</Trans>
             </Checkbox>
             <Checkbox
               isChecked={queryParams.manuallyEnded === 'true'}
-              onChange={(e) => setQueryParams({ ...queryParams, manuallyEnded: e.target.checked ? 'true' : undefined })}
+              onChange={(e) => setFilters({ ...queryParams, manuallyEnded: e.target.checked ? 'true' : undefined })}
             >
               <Trans i18nKey='process.manually_ended'>Manually ended</Trans>
             </Checkbox>
@@ -70,8 +74,14 @@ const PopoverFilter = () => {
 
 export const ProcessSearchBox = () => {
   const { t } = useTranslation()
-  const { queryParams, setQueryParams } = useQueryParams<FilterQueryParams>()
   const [isInvalid, setIsInvalid] = useState(false)
+
+  const { queryParams, getNewParams } = useQueryParams<FilterQueryParams>()
+  const { setPage } = useRoutedPagination()
+
+  const setFilters = (filters: Partial<FilterQueryParams>) => {
+    setPage(1, `?${getNewParams(filters).toString()}`)
+  }
 
   return (
     <FormControl isInvalid={isInvalid}>
@@ -85,7 +95,7 @@ export const ProcessSearchBox = () => {
               const isInvalid = value !== '' && !isValidPartialProcessId(value)
               setIsInvalid(isInvalid)
               if (!isInvalid) {
-                setQueryParams({ ...queryParams, electionId: value })
+                setFilters({ ...queryParams, electionId: value })
               }
             }}
             initialValue={queryParams.electionId}
@@ -101,7 +111,12 @@ export const ProcessSearchBox = () => {
 
 export const ProcessByTypeFilter = () => {
   const { t } = useTranslation()
-  const { queryParams, setQueryParams } = useQueryParams<FilterQueryParams>()
+  const { queryParams, getNewParams } = useQueryParams<FilterQueryParams>()
+  const { setPage } = useRoutedPagination()
+
+  const setFilters = (filters: Partial<FilterQueryParams>) => {
+    setPage(1, `?${getNewParams(filters).toString()}`)
+  }
 
   const currentStatus = queryParams.status
 
@@ -130,7 +145,7 @@ export const ProcessByTypeFilter = () => {
         <Button
           flex={{ base: 'none', md: '1' }}
           key={i}
-          onClick={() => setQueryParams({ ...queryParams, status: filter.value })}
+          onClick={() => setFilters({ ...queryParams, status: filter.value })}
           variant={currentStatus !== filter.value ? 'solid' : 'outline'}
         >
           {filter.label}
@@ -140,15 +155,7 @@ export const ProcessByTypeFilter = () => {
   )
 }
 
-export const PaginatedProcessList = () => {
-  return (
-    <RoutedPaginationProvider path={RoutePath.ProcessesList}>
-      <ProcessList />
-    </RoutedPaginationProvider>
-  )
-}
-
-const ProcessList = () => {
+export const ProcessList = () => {
   const { page }: { page?: number } = useRoutedPagination()
   const { queryParams: processFilters } = useQueryParams<FilterQueryParams>()
 

--- a/src/components/Process/ProcessList.tsx
+++ b/src/components/Process/ProcessList.tsx
@@ -20,24 +20,19 @@ import { ContentError, NoResultsError } from '~components/Layout/ContentError'
 import { useRoutedPagination } from '~components/Pagination/PaginationProvider'
 import { RoutedPagination } from '~components/Pagination/RoutedPagination'
 import { useProcessList } from '~queries/processes'
-import useQueryParams from '~src/router/use-query-params'
 import { isEmpty } from '~utils/objects'
 import { ElectionCard } from './Card'
 import { LuListFilter } from 'react-icons/lu'
 import { isValidPartialProcessId } from '~utils/strings'
 import { useState } from 'react'
+import { useRoutedPaginationQueryParams } from '~src/router/use-query-params'
 
 type FilterQueryParams = {
   [K in keyof Omit<FetchElectionsParameters, 'organizationId'>]: string
 }
 
 const PopoverFilter = () => {
-  const { queryParams, getNewParams } = useQueryParams<FilterQueryParams>()
-  const { setPage } = useRoutedPagination()
-
-  const setFilters = (filters: Partial<FilterQueryParams>) => {
-    setPage(1, `?${getNewParams(filters).toString()}`)
-  }
+  const { queryParams, setQueryParams } = useRoutedPaginationQueryParams<FilterQueryParams>()
 
   return (
     <Popover>
@@ -49,19 +44,19 @@ const PopoverFilter = () => {
           <Flex direction={'column'}>
             <Checkbox
               isChecked={queryParams.withResults === 'true'}
-              onChange={(e) => setFilters({ ...queryParams, withResults: e.target.checked ? 'true' : undefined })}
+              onChange={(e) => setQueryParams({ ...queryParams, withResults: e.target.checked ? 'true' : undefined })}
             >
               <Trans i18nKey='process.show_with_results'>Show only processes with results</Trans>
             </Checkbox>
             <Checkbox
               isChecked={queryParams.finalResults === 'true'}
-              onChange={(e) => setFilters({ ...queryParams, finalResults: e.target.checked ? 'true' : undefined })}
+              onChange={(e) => setQueryParams({ ...queryParams, finalResults: e.target.checked ? 'true' : undefined })}
             >
               <Trans i18nKey='process.final_results'>Final results</Trans>
             </Checkbox>
             <Checkbox
               isChecked={queryParams.manuallyEnded === 'true'}
-              onChange={(e) => setFilters({ ...queryParams, manuallyEnded: e.target.checked ? 'true' : undefined })}
+              onChange={(e) => setQueryParams({ ...queryParams, manuallyEnded: e.target.checked ? 'true' : undefined })}
             >
               <Trans i18nKey='process.manually_ended'>Manually ended</Trans>
             </Checkbox>
@@ -75,13 +70,7 @@ const PopoverFilter = () => {
 export const ProcessSearchBox = () => {
   const { t } = useTranslation()
   const [isInvalid, setIsInvalid] = useState(false)
-
-  const { queryParams, getNewParams } = useQueryParams<FilterQueryParams>()
-  const { setPage } = useRoutedPagination()
-
-  const setFilters = (filters: Partial<FilterQueryParams>) => {
-    setPage(1, `?${getNewParams(filters).toString()}`)
-  }
+  const { queryParams, setQueryParams } = useRoutedPaginationQueryParams<FilterQueryParams>()
 
   return (
     <FormControl isInvalid={isInvalid}>
@@ -95,7 +84,7 @@ export const ProcessSearchBox = () => {
               const isInvalid = value !== '' && !isValidPartialProcessId(value)
               setIsInvalid(isInvalid)
               if (!isInvalid) {
-                setFilters({ ...queryParams, electionId: value })
+                setQueryParams({ ...queryParams, electionId: value })
               }
             }}
             initialValue={queryParams.electionId}
@@ -111,12 +100,7 @@ export const ProcessSearchBox = () => {
 
 export const ProcessByTypeFilter = () => {
   const { t } = useTranslation()
-  const { queryParams, getNewParams } = useQueryParams<FilterQueryParams>()
-  const { setPage } = useRoutedPagination()
-
-  const setFilters = (filters: Partial<FilterQueryParams>) => {
-    setPage(1, `?${getNewParams(filters).toString()}`)
-  }
+  const { queryParams, setQueryParams } = useRoutedPaginationQueryParams<FilterQueryParams>()
 
   const currentStatus = queryParams.status
 
@@ -145,7 +129,7 @@ export const ProcessByTypeFilter = () => {
         <Button
           flex={{ base: 'none', md: '1' }}
           key={i}
-          onClick={() => setFilters({ ...queryParams, status: filter.value })}
+          onClick={() => setQueryParams({ ...queryParams, status: filter.value })}
           variant={currentStatus !== filter.value ? 'solid' : 'outline'}
         >
           {filter.label}
@@ -157,7 +141,7 @@ export const ProcessByTypeFilter = () => {
 
 export const ProcessList = () => {
   const { page }: { page?: number } = useRoutedPagination()
-  const { queryParams: processFilters } = useQueryParams<FilterQueryParams>()
+  const { queryParams: processFilters } = useRoutedPaginationQueryParams<FilterQueryParams>()
 
   const { data, isLoading, isFetching, isError, error } = useProcessList({
     filters: {

--- a/src/components/Process/ProcessList.tsx
+++ b/src/components/Process/ProcessList.tsx
@@ -1,7 +1,10 @@
 import {
+  Box,
   Button,
   Checkbox,
   Flex,
+  FormControl,
+  FormErrorMessage,
   IconButton,
   Popover,
   PopoverBody,
@@ -22,6 +25,8 @@ import useQueryParams from '~src/router/use-query-params'
 import { isEmpty } from '~utils/objects'
 import { ElectionCard } from './Card'
 import { LuListFilter } from 'react-icons/lu'
+import { isValidPartialProcessId } from '~utils/strings'
+import { useState } from 'react'
 
 type FilterQueryParams = {
   [K in keyof Omit<FetchElectionsParameters, 'organizationId'>]: string
@@ -66,22 +71,31 @@ const PopoverFilter = () => {
 export const ProcessSearchBox = () => {
   const { t } = useTranslation()
   const { queryParams, setQueryParams } = useQueryParams<FilterQueryParams>()
+  const [isInvalid, setIsInvalid] = useState(false)
 
   return (
-    <Flex direction={{ base: 'column', lg: 'row' }} flexDirection={{ base: 'column-reverse', lg: 'row' }} gap={4}>
-      <PopoverFilter />
-      <Flex>
-        <InputSearch
-          maxW={'300px'}
-          placeholder={t('process.search_by')}
-          onChange={(value: string) => {
-            setQueryParams({ ...queryParams, electionId: value })
-          }}
-          initialValue={queryParams.electionId}
-          debounceTime={500}
-        />
+    <FormControl isInvalid={isInvalid}>
+      <Flex direction={{ base: 'column', lg: 'row' }} flexDirection={{ base: 'column', md: 'row' }} gap={4}>
+        <PopoverFilter />
+        <Flex direction={'column'}>
+          <InputSearch
+            maxW={'300px'}
+            placeholder={t('process.search_by')}
+            onChange={(value: string) => {
+              const isInvalid = value !== '' && !isValidPartialProcessId(value)
+              setIsInvalid(isInvalid)
+              if (!isInvalid) {
+                setQueryParams({ ...queryParams, electionId: value })
+              }
+            }}
+            initialValue={queryParams.electionId}
+            debounceTime={500}
+            isInvalid={isInvalid}
+          />
+          <Box minHeight='25px'>{isInvalid && <FormErrorMessage>Not valid partial process id</FormErrorMessage>}</Box>
+        </Flex>
       </Flex>
-    </Flex>
+    </FormControl>
   )
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,7 +24,7 @@ export enum RoutePath {
   BlocksList = '/blocks/:page?',
   Envelope = '/envelope/:verifier/:tab?',
   Account = '/account/:pid/:tab?/:page?',
-  AccountsList = '/accounts/:page?/:query?',
+  AccountsList = '/accounts/:page?',
   Process = '/process/:pid/:tab?',
   ProcessesList = '/processes/:page?',
   Transaction = '/transactions/:block/:index/:tab?',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,7 +42,7 @@ export enum OldRoutePath {
   OrganizationDetails = '/organizations/show/#/',
   ProcessDetails = '/processes/show/#/',
   TransactionDetails = '/transactions/show/#/',
-  Verify = '/verify',
+  Verify = '/verify/#/',
   Stats = '/stats',
   OrganizationsList = '/organizations',
   Organization = '/organization',

--- a/src/pages/accounts.tsx
+++ b/src/pages/accounts.tsx
@@ -1,8 +1,9 @@
-import { AccountsFilter, PaginatedAccountsList } from '~components/Accounts/List'
+import { AccountsFilter, AccountsList } from '~components/Accounts/List'
 import ListPageLayout from '~components/Layout/ListPageLayout'
 import { useOrganizationCount } from '~queries/accounts'
 import { useTranslation } from 'react-i18next'
-import { RefreshIntervalPagination } from '~constants'
+import { RefreshIntervalPagination, RoutePath } from '~constants'
+import { RoutedPaginationProvider } from '~components/Pagination/PaginationProvider'
 
 const OrganizationList = () => {
   const { t } = useTranslation()
@@ -13,9 +14,11 @@ const OrganizationList = () => {
   const subtitle = !isLoading ? t('accounts.accounts_count', { count: orgsCount || 0 }) : ''
 
   return (
-    <ListPageLayout title={t('accounts.accounts_list')} subtitle={subtitle} rightComponent={<AccountsFilter />}>
-      <PaginatedAccountsList />
-    </ListPageLayout>
+    <RoutedPaginationProvider path={RoutePath.AccountsList}>
+      <ListPageLayout title={t('accounts.accounts_list')} subtitle={subtitle} rightComponent={<AccountsFilter />}>
+        <AccountsList />
+      </ListPageLayout>
+    </RoutedPaginationProvider>
   )
 }
 

--- a/src/pages/processes.tsx
+++ b/src/pages/processes.tsx
@@ -1,8 +1,13 @@
 import ListPageLayout from '~components/Layout/ListPageLayout'
 import { useTranslation } from 'react-i18next'
 import { useProcessesCount } from '~queries/processes'
-import { PaginatedProcessList, ProcessByTypeFilter, ProcessSearchBox } from '~components/Process/ProcessList'
-import { RefreshIntervalPagination } from '~constants'
+import {
+  ProcessList as PaginatedProcessList,
+  ProcessByTypeFilter,
+  ProcessSearchBox,
+} from '~components/Process/ProcessList'
+import { RefreshIntervalPagination, RoutePath } from '~constants'
+import { RoutedPaginationProvider } from '~components/Pagination/PaginationProvider'
 
 const ProcessList = () => {
   const { t } = useTranslation()
@@ -13,10 +18,12 @@ const ProcessList = () => {
   const subtitle = !isLoading ? t('process.process_count', { count: data || 0 }) : ''
 
   return (
-    <ListPageLayout title={t('process.process_list')} subtitle={subtitle} rightComponent={<ProcessSearchBox />}>
-      <ProcessByTypeFilter />
-      <PaginatedProcessList />
-    </ListPageLayout>
+    <RoutedPaginationProvider path={RoutePath.ProcessesList}>
+      <ListPageLayout title={t('process.process_list')} subtitle={subtitle} rightComponent={<ProcessSearchBox />}>
+        <ProcessByTypeFilter />
+        <PaginatedProcessList />
+      </ListPageLayout>
+    </RoutedPaginationProvider>
   )
 }
 

--- a/src/router/use-query-params.ts
+++ b/src/router/use-query-params.ts
@@ -1,7 +1,10 @@
 import { useMemo } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { useRoutedPagination } from '~components/Pagination/PaginationProvider'
 
-const useQueryParams = <T extends Record<string, string>>() => {
+export type QueryParamsType = Record<string, string>
+
+const useQueryParams = <T extends QueryParamsType>() => {
   const { search } = useLocation()
   const navigate = useNavigate()
   const location = useLocation()
@@ -33,6 +36,20 @@ const useQueryParams = <T extends Record<string, string>>() => {
   }
 
   return { queryParams, setQueryParams, getNewParams }
+}
+
+/**
+ * Hook to manage query params and pagination.
+ * When a query param is set, the page is reset to 1.
+ */
+export const useRoutedPaginationQueryParams = <T extends QueryParamsType>() => {
+  const { queryParams, getNewParams } = useQueryParams<T>()
+  const { setPage } = useRoutedPagination()
+  const setQueryParams = (filters: Partial<T>) => {
+    setPage(1, `?${getNewParams(filters).toString()}`)
+  }
+
+  return { queryParams, setQueryParams }
 }
 
 export default useQueryParams

--- a/src/router/use-query-params.ts
+++ b/src/router/use-query-params.ts
@@ -16,7 +16,7 @@ const useQueryParams = <T extends Record<string, string>>() => {
     return queryObj
   }, [search])
 
-  const setQueryParams = (newParams: Partial<T>) => {
+  const getNewParams = (newParams: Partial<T>) => {
     const params = new URLSearchParams(search)
     for (const key in newParams) {
       if (newParams[key]) {
@@ -25,10 +25,14 @@ const useQueryParams = <T extends Record<string, string>>() => {
         params.delete(key)
       }
     }
-    navigate(`${location.pathname}?${params.toString()}`)
+    return params
   }
 
-  return { queryParams, setQueryParams }
+  const setQueryParams = (newParams: Partial<T>) => {
+    navigate(`${location.pathname}?${getNewParams(newParams).toString()}`)
+  }
+
+  return { queryParams, setQueryParams, getNewParams }
 }
 
 export default useQueryParams


### PR DESCRIPTION
Fixes https://github.com/vocdoni/explorer/issues/113
Fixes https://github.com/vocdoni/explorer/issues/114

- When a filter is set, on accounts list page or on a process list page, it resets set the page to the first page. This was done refactoring the `RoutedPaginationProvider` exposing a `setPage` function. This function accepts a `queyParams` attribute so we can set the page and queryParams at same time. Then a hook `useRoutedPaginationQueryParams` is created to wrap a function that set the query params and reset de pago to the firs one
- Add not valid process id message on the process list page: if the process id is odd and not an hex string, it doesn't do the call and show a form error message
- Fix verify old route: the old path route has the missing `#` causing the router to add a `//` after the url when accessing to `verify/` 
- Use query params for accounts list filter instead of using route params. This uses the routed paginator refactor