### PR TITLE
Add questions type badge

### DIFF
--- a/src/components/Process/Detail.tsx
+++ b/src/components/Process/Detail.tsx
@@ -25,6 +25,7 @@ import {
   ElectionResults,
   ElectionSchedule,
   ElectionTitle,
+  QuestionsTypeBadge,
 } from '@vocdoni/chakra-components'
 import { useElection } from '@vocdoni/react-providers'
 import {
@@ -108,6 +109,7 @@ const Detail = () => {
       </Flex>
       {/*Information tags */}
       <Flex wrap={'wrap'} gap={2}>
+        <QuestionsTypeBadge />
         {election.fromArchive && (
           <Tag variant={'vocdoni'}>
             <Trans i18nKey={'process.badge.archive'}>From archive</Trans>

--- a/src/theme/components/QuestionsTypeBadge.ts
+++ b/src/theme/components/QuestionsTypeBadge.ts
@@ -1,0 +1,21 @@
+import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
+import { questionTypeBadgeAnatomy } from '@vocdoni/chakra-components'
+import { vocdoniStatusBadge } from '~src/theme/components/Tag'
+
+const { defineMultiStyleConfig, definePartsStyle } = createMultiStyleConfigHelpers(questionTypeBadgeAnatomy)
+
+const baseStyle = definePartsStyle({
+  wrapper: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  box: {
+    ...vocdoniStatusBadge.container,
+    height: '24px',
+  },
+})
+
+export const QuestionsTypeBadge = defineMultiStyleConfig({
+  baseStyle,
+})

--- a/src/theme/components/Tag.ts
+++ b/src/theme/components/Tag.ts
@@ -3,7 +3,7 @@ import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
 
 const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpers(tagAnatomy.keys)
 
-const vocdoniStatusBadge = definePartsStyle({
+export const vocdoniStatusBadge = definePartsStyle({
   container: {
     padding: '4px 12px',
     borderRadius: '4px',

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -6,6 +6,7 @@ import Questions from './Questions'
 import Radio from './Radio'
 import Tag from './Tag'
 import Envelope from '~src/theme/components/Envelope'
+import { QuestionsTypeBadge } from '~src/theme/components/QuestionsTypeBadge'
 
 const components = {
   Card,
@@ -13,6 +14,7 @@ const components = {
   ElectionHeader,
   Envelope,
   Questions,
+  QuestionsTypeBadge,
   Radio,
   ElectionResults,
   Tag,


### PR DESCRIPTION
Fixes https://github.com/vocdoni/explorer/issues/92

Show questions type badge as a tag on election details:

![image](https://github.com/user-attachments/assets/384bc042-8e1e-476a-986b-40e96fdb1ab1)

